### PR TITLE
Modifications and bug fixes for TCEC Season 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ Monolith is not a standalone chess program and needs a graphical interface in or
 
 
 ## Strength
-Monolith 1 is ranked at around 2850 Elo on [CCRL 40/15](https://www.computerchess.org.uk/ccrl/4040/cgi/engine_details.cgi?print=Details&each_game=1&eng=Monolith%201.0%2064-bit%204CPU#Monolith_1_0_64-bit_4CPU) and 2910 Elo on [CCRL Blitz](https://www.computerchess.org.uk/ccrl/404/cgi/engine_details.cgi?print=Details&each_game=1&eng=Monolith%201.0%2064-bit%204CPU#Monolith_1_0_64-bit_4CPU).\
-Monolith 2 is considerably stronger in bullet games:
-> Score of Monolith 2 vs Monolith 1: 6949 - 886 - 2165  [0.803] 10000\
-Elo difference: 244.26 +/- 6.94
+Monolith 2 running on a single CPU-thread is ranked at around 3000 Elo on [CCRL 40/15](https://www.computerchess.org.uk/ccrl/4040/cgi/engine_details.cgi?print=Details&each_game=1&eng=Monolith%202%2064-bit#Monolith_2_64-bit),
+2980 Elo on [CCRL Blitz](https://www.computerchess.org.uk/ccrl/404/cgi/engine_details.cgi?match_length=30&each_game=1&print=Details&each_game=1&eng=Monolith%202%2064-bit#Monolith_2_64-bit)
+and 3120 Elo on [CCRL 40/2 FRC](https://www.computerchess.org.uk/ccrl/404FRC/cgi/engine_details.cgi?print=Details&each_game=1&eng=Monolith%202%2064-bit#Monolith_2_64-bit).
 
 
 ## Main features
@@ -39,7 +38,7 @@ Elo difference: 244.26 +/- 6.94
 
 
 #### You can compile it yourself
-Run `make release [ARCH=architecture] [COMP=compiler]`
+Run `make [ARCH=architecture] [COMP=compiler]`
 - supported architectures, see above for more detailed descriptions:\
 `x64-pext`, `x64-popcnt`, `x64`, `x86`, `armv8`, `armv7`;
 - some supported compilers:
@@ -67,7 +66,7 @@ Running the Monolith `bench` command should result in a total of `22296396` node
 - **`SyzygyProbeLimit`**: Number of pieces that have to be on the board in the endgame before the table-bases are probed. Default is `7` which is the upper limit of pieces that Syzygy table-bases currently support.
 
 
-### Additional unofficial commands
+#### Additional unofficial commands
 - `bench`: Running a couple of benchmark searches of an internal set of various positions.
 - `perft [depth]`: Running perft up to [depth] on the current position.
 - `eval`: Computing the static evaluation of the current position without the use of the search function.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Monolith 2
 
 Monolith is a powerful open source chess engine written in C++17, compliant with the Universal Chess Interface (UCI) protocol.
-It uses the traditional alpha-beta search algorithm. The search and parallelization-algorithms, the position evaluation principles,
+It uses the alpha-beta search algorithm. The search and parallelization-algorithms, the position evaluation principles,
 the fast move-generating methods, the support for opening books and endgame table-bases, all of it wasn't newly invented in this engine.
 Monolith is rather a new original implementation of many well-established concepts of computer chess, resulting in its own unique personality as a chess playing entity.
 

--- a/Source/magic.cpp
+++ b/Source/magic.cpp
@@ -156,7 +156,7 @@ namespace magic
 
 				for (int p{}; !fail && p < permutations; ++p)
 				{
-					int index{ static_cast<int>(blocker[sq.offset + p] * sq.magic >> sq.shift) };
+					int index{ int(blocker[sq.offset + p] * sq.magic >> sq.shift) };
 					verify(index <= permutations);
 
 					if (!save_attack[index])

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -39,7 +39,7 @@ void verify_expr(const bool& condition, const char* expression, const char* file
     abort();
 }
 
-int main(int, char* argv[])
+int main()
 {
 	std::cout << "Monolith " << uci::version_number << std::endl;
 
@@ -47,11 +47,11 @@ int main(int, char* argv[])
 
 	bit::init_masks();
 	zobrist::init_keys();
-    trans::create(uci::hash_size);
+	trans::create(uci::hash_size);
 	magic::init_table();
-	filesystem::init_path(argv);
+	filesystem::init_path();
 	eval::mirror_tables();
-    search::init_tables();
+	search::init_tables();
 	syzygy::init_tb(uci::syzygy.path);
 
 	uci::loop();

--- a/Source/makefile
+++ b/Source/makefile
@@ -67,7 +67,7 @@ endif
 OS = $(shell uname -s)
 
 ifneq ($(ARCH),native)
-    ANNEX = -$(ARCH)
+    NAME := $(NAME)-$(ARCH)
 endif
 
 ifeq ($(ARCH),$(filter $(ARCH),armv7 armv8))
@@ -83,11 +83,13 @@ ifeq ($(OS),Linux)
     CFLAGS += -flto
 endif
 
-ifneq ($(OS),Linux)
 ifneq ($(OS),Android)
-    CFLAGS += -static
-    ANNEX   = -$(ARCH).exe
-endif
+    ifeq ($(OS),Linux)
+        RFLAGS += -static -lrt -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
+    else
+        CFLAGS += -static
+        NAME   := $(NAME).exe
+    endif
 endif
 
 # compiler specific additions
@@ -102,20 +104,21 @@ endif
 
 # targets
 
-all: release
+all:
+	$(COMP) $(CFLAGS) $(WFLAGS) -DNDEBUG $(SOURCE) $(LFLAGS) -o $(NAME)
 
 release:
-	$(COMP) $(CFLAGS) $(WFLAGS) -DNDEBUG $(SOURCE) $(LFLAGS) -o $(NAME)$(ANNEX)
+	$(COMP) $(CFLAGS) $(WFLAGS) $(RFLAGS) -DNDEBUG $(SOURCE) $(LFLAGS) -o $(NAME)
 
 debug:
-	$(COMP) $(CFLAGS) $(WFLAGS) $(SOURCE) $(LFLAGS) -o $(NAME)$(ANNEX)
+	$(COMP) $(CFLAGS) $(WFLAGS) $(SOURCE) $(LFLAGS) -o $(NAME)
 
 debug_deep:
-	$(COMP) $(CFLAGS) $(WFLAGS) -DDEBUG_DEEP $(SOURCE) $(LFLAGS) -o $(NAME)$(ANNEX)
+	$(COMP) $(CFLAGS) $(WFLAGS) -DDEBUG_DEEP $(SOURCE) $(LFLAGS) -o $(NAME)
 
 tune:
-	$(COMP) $(CFLAGS) $(WFLAGS) -DNDEBUG -DTUNE $(SOURCE) $(LFLAGS) -o $(NAME)-tune-$(ANNEX)
+	$(COMP) $(CFLAGS) $(WFLAGS) -DNDEBUG -DTUNE $(SOURCE) $(LFLAGS) -o $(NAME)
 
 help:
-	@echo "make release [ARCH=architecture] [COMP=compiler]"
+	@echo "make [ARCH=architecture] [COMP=compiler]"
 	@echo "see readme.md for more details"

--- a/Source/misc.h
+++ b/Source/misc.h
@@ -25,20 +25,13 @@
 #include "types.h"
 #include "main.h"
 
-// the Android NDK doesn't support the standard library <filesystem> yet
-
-#if !defined(__ANDROID__)
-#include <filesystem>
-#else
-#include <errno.h>
-#endif
-
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
 #include <windows.h>
+#include <direct.h>
 #define fd_error INVALID_HANDLE_VALUE
 
 using mem_map = HANDLE;
@@ -62,7 +55,7 @@ namespace filesystem
 	// keeping track of the binary file location
 
 	extern std::string path;
-	void init_path(char* argv[]);
+	void init_path();
 }
 
 // providing memory functionality

--- a/Source/polyglot.cpp
+++ b/Source/polyglot.cpp
@@ -99,7 +99,7 @@ template<typename uint> uint book::read_int()
 
 	uint assembly{};
 	for (auto& b : buf)
-		assembly = (assembly << 8) | static_cast<uint8>(b);
+		assembly = (assembly << 8) | uint8(b);
 	return assembly;
 }
 

--- a/Source/syzygy.cpp
+++ b/Source/syzygy.cpp
@@ -176,6 +176,16 @@ namespace
 	constexpr int wdl_to_score[]{ tb_loss, blessed_loss, draw, cursed_win, tb_win };
 	constexpr int wdl_to_map[]{  1,    3, 0,   2, 0 };
 	constexpr int wdl_to_dtz[]{ -1, -101, 0, 101, 1 };
+	
+	// differentiating OS-specific elements of the path-string
+
+#if !defined(_WIN32)
+	constexpr char path_sep{ ':' };
+	constexpr char  end_sep{ '/' };
+#else
+	constexpr char path_sep{ ';' };
+	constexpr char  end_sep{ '\\' };
+#endif
 }
 
 // encryption arrays
@@ -454,7 +464,7 @@ namespace tbcore
 
 		for (auto& p : paths)
 		{
-			std::string fullpath{ p + "\\" + name };
+			std::string fullpath{ p + end_sep + name };
 			FD fd(memory::open_tb(fullpath));
 			if (fd != fd_error) return fd;
 		}
@@ -1326,15 +1336,9 @@ void syzygy::init_tb(const std::string& path)
 	path_string = path;
 	if (path_string.empty() || path_string == "<empty>") return;
 
-#if !defined(_WIN32)
-	char sep{ ':' };
-#else
-	char sep{ ';' };
-#endif
-
 	for (uint32 i{ 1 }, j{}; i < path_string.size(); ++i)
 	{
-		if (i + 1 == path_string.size() || path_string[i + 1] == sep)
+		if (i + 1 == path_string.size() || path_string[i + 1] == path_sep)
 		{
 			paths.push_back(path_string.substr(j, i + 1 - j));
 			j = i + 2;

--- a/Source/texel.cpp
+++ b/Source/texel.cpp
@@ -17,7 +17,7 @@
 */
 
 
-// all credits for the Texel tuning approach go to Peter Österlund:
+// all credits for the Texel tuning approach go to Peter Ã–sterlund:
 // https://www.chessprogramming.org/Texel%27s_Tuning_Method
 
 #include "texel.h"
@@ -309,13 +309,13 @@ namespace texel
 		for (auto& t : threads)
 		{
 			t = std::thread{ eval_error_range, std::ref(texel_pos), std::ref(error), k,
-				int(std::floor(range_min)), int(std::floor(range_min + share)) };
+				int(std::floor(range_min)), int(std::floor(range_min + share) - 1) };
 			range_min += share;
 		}
 		for (auto& t : threads)
 			t.join();
 
-		verify(std::size_t(std::floor(range_min)) + 1 == texel_pos.size());
+		verify(std::size_t(std::floor(range_min)) == texel_pos.size());
 		return error / double(texel_pos.size());
 	}
 

--- a/Source/types.h
+++ b/Source/types.h
@@ -174,7 +174,7 @@ inline std::istream& operator >>(std::istream& is, milliseconds& time) { int t{}
 namespace lim
 {
 	constexpr int64 nodes{ std::numeric_limits<int64>::max() };
-	constexpr int threads{ 128 };
+	constexpr int threads{ 256 };
 	constexpr int syzygy_pieces{ 7 };
 
 	constexpr milliseconds movetime{ milliseconds::max() };


### PR DESCRIPTION
Modifications and bug fixes for TCEC Season 18 (bench stays at `22296396`):
- Maximal thread-count was increased to 256 (testing with 176 threads worked well).
- For Linux systems, a bug in filepath handling was fixed. The UCI options SyzygyPath, Log and OwnBook were affected and not working beforehand.
- For Linux systems, the makefile was modified to link all libraries statically when targeting release build. This fixes compatibility issues when running on different distribution.
- Some code cleanup and an inaccuracy-fix in Texel tuning code.